### PR TITLE
fix the order of the args for the ets lookup

### DIFF
--- a/examples/kv_battle/test/bench_kv.erl
+++ b/examples/kv_battle/test/bench_kv.erl
@@ -90,6 +90,6 @@ ets({input, Tab}) ->
     ok.
 
 bench_ets(_, Tab) ->
-    {ets:lookup(-1, Tab),
-     ets:lookup(5000, Tab),
-     ets:lookup(1000000, Tab)}.
+    {ets:lookup(Tab, -1),
+     ets:lookup(Tab, 5000),
+     ets:lookup(Tab, 1000000)}.


### PR DESCRIPTION
With the original order bench_ets/2 was crashing with badarg exception.