### PR TITLE
enable running the benchmarks without the stats

### DIFF
--- a/src/rebar3_bench_prv.erl
+++ b/src/rebar3_bench_prv.erl
@@ -85,7 +85,7 @@ run_benches(Benches, Baseline, OptsL) ->
               rebar_api:debug("Raw samples:~n~p", [Samples]),
               case maps:get(cover, Opts, false) of
                   false ->
-                      case maps:get(no_stats, Opts) of
+                      case maps:get(no_stats, Opts, false) of
                           true ->
                               noop;
                           false ->

--- a/src/rebar3_bench_prv.erl
+++ b/src/rebar3_bench_prv.erl
@@ -68,6 +68,8 @@ opts() ->
       "run benchmarks in coverage mode (no measurements are made), generate cover data"},
      {parameter, $p, "parameter", {string, "wall_time"},
       "which parameter to measure: wall_time, memory, reductions"},
+     {no_stats, undefined, "no-stats", {boolean, false},
+      "do not produce summary stats"},
      {save_baseline, undefined, "save-baseline", {string, "_tip"},
       "save benchmark data to file with this name"},
      {baseline, undefined, "baseline", {string, "_tip"},
@@ -83,8 +85,13 @@ run_benches(Benches, Baseline, OptsL) ->
               rebar_api:debug("Raw samples:~n~p", [Samples]),
               case maps:get(cover, Opts, false) of
                   false ->
-                      Stats = stats(Mod, Fun, Samples, Baseline, Opts),
-                      report(Stats, Opts);
+                      case maps:get(no_stats, Opts) of
+                          true ->
+                              noop;
+                          false ->
+                              Stats = stats(Mod, Fun, Samples, Baseline, Opts),
+                              report(Stats, Opts)
+                      end;
                   true ->
                       %% Don't print the report when `cover' option is provided
                       noop


### PR DESCRIPTION
This allows use cases where we only want to collect the measurements for storage and processing at a later point in time.

We can have multiple runs for various versions/commits, collect the data, then compare them by running eministat offline on select batch runs.
